### PR TITLE
Checks the trees can grow before growing, tries again if it can't grow, does not affect generation

### DIFF
--- a/redtrees/init.lua
+++ b/redtrees/init.lua
@@ -91,7 +91,7 @@ end
 
 --MAKE TREE!!
 
-redtrees.grow_tree = function(pos)
+function spawn_tree(pos)
 	local x, y, z = pos.x, pos.y, pos.z
 	local height = random(4, 6)
 	local c_tree = minetest.get_content_id("redtrees:rtree")
@@ -112,9 +112,18 @@ redtrees.grow_tree = function(pos)
 	vm:update_map()
 end
 
+redtrees.grow_tree = function(pos)
+	if not can_grow(pos) then
+		-- try a bit later again
+		minetest.get_node_timer(pos):start(math.random(240, 600))
+		return
+	end
+	spawn_tree(pos)
+end
+
 redtrees.generate_tree = function(pos)
 	pos.y = pos.y + 1
-	redtrees.grow_tree(pos)
+	spawn_tree(pos)
 end
 
 --SUDO PLACE TREE!!!

--- a/sakuragi/init.lua
+++ b/sakuragi/init.lua
@@ -90,7 +90,7 @@ local function add_trunk_and_leaves(data, a, pos, tree_cid, leaves_cid,
 end
 
 --MAKE TREE!!
-sakuragi.grow_tree = function(pos)
+function spawn_tree(pos)
 	local x, y, z = pos.x, pos.y, pos.z
 	local height = random(4, 6)
 	local c_tree = minetest.get_content_id("sakuragi:stree")
@@ -111,9 +111,18 @@ sakuragi.grow_tree = function(pos)
 	vm:update_map()
 end
 
+sakuragi.grow_tree = function(pos)
+	if not can_grow(pos) then
+		-- try a bit later again
+		minetest.get_node_timer(pos):start(math.random(240, 600))
+		return
+	end
+	spawn_tree(pos)
+end
+
 sakuragi.generate_tree = function(pos)
 	pos.y = pos.y + 1
-	sakuragi.grow_tree(pos)
+	spawn_tree(pos)
 end
 --SUDO PLACE TREE!!!
 biome_lib:register_generate_plant({


### PR DESCRIPTION
Fixes BLS issue 207 https://github.com/BlockySurvival/issue-tracker/issues/207

There was already a `can_grow` function that just wasn't being used.

Put the current grow function into a new spawn function that can be called from grow and generate separately, this allows us to have different behaviour between generate & user grown, the neglect of which was probably the reason the check function was not originally used